### PR TITLE
관리자 모델 추가, 관리자 이메일 목록 모델 추가, 구글 로그인 API 구현

### DIFF
--- a/managers/models.py
+++ b/managers/models.py
@@ -4,7 +4,6 @@ from django.utils.timezone import localtime
 from utils.choices import InterviewMethodChoices
 
 class Manager(AbstractUser):
-    id = models.AutoField(primary_key=True)
     email = models.EmailField(
         unique=True,
         blank=False,
@@ -13,7 +12,6 @@ class Manager(AbstractUser):
     password = models.CharField(max_length=128)
     
 class AllowedManagerEmail(models.Model):
-    id = models.AutoField(primary_key=True)
     email = models.EmailField(unique=True)
     is_active = models.BooleanField(default=True)
     memo = models.CharField(max_length=200, blank=True, default="")


### PR DESCRIPTION
## 🔎 What is this PR?
<img width="412" height="107" alt="image" src="https://github.com/user-attachments/assets/25b6fa29-2cec-48b6-b9f2-b0a2443740c0" />

- 관리자 구글 로그인
- https://www.notion.so/182cc780cd7d81508710f25d694c821e?p=2d5cc780cd7d80e79a29d9919087f6af&pm=s

## ✨ Changes
- Manager 모델을 추가하고, `AUTH_USER_MODEL`을 `managers.manager`로 변경했습니다.
- 시스템 관리자(superuser)가 관리하는 관리자 이메일 목록 테이블(`AllowedManagerEmail`)을 추가했습니다. 해당 테이블에 이메일이 있는 계정만 로그인이 가능합니다.
- 프론트엔드로부터 구글 계정의 `id_token`을 받아 관리자 이메일 목록에 해당 이메일이 있는지 검사, 관리자가 맞을 시 access token과 refresn token을 발급하는 기능을 추가했습니다.
- `google_text.html`을 통해 `id_token`을 발급하여 API 기능을 테스트했습니다.
<테스트 페이지 코드>
```
<!doctype html>
<html>
  <head>
    <meta charset="utf-8" />
    <title>Google ID Token Test</title>
    <script src="https://accounts.google.com/gsi/client" async defer></script>
  </head>
  <body>
    <h3>Google ID Token Test</h3>
    <div id="g_id_onload"
         data-client_id={{GOOGLE_CLIENT_ID}}
         data-callback="handleCredentialResponse">
    </div>
    <div class="g_id_signin" data-type="standard"></div>

    <pre id="out" style="white-space: pre-wrap;"></pre>

    <script>
      function handleCredentialResponse(response) {
        // response.credential 이 id_token
        document.getElementById("out").textContent = response.credential;
        console.log("id_token:", response.credential);
      }
    </script>
  </body>
</html>

```

## 📷 Result

<img width="1408" height="806" alt="스크린샷 2025-12-27 140914" src="https://github.com/user-attachments/assets/cc1cebb0-a9c8-4aae-8b1c-a63cd922c165" />
로그인 성공 시

<img width="1381" height="635" alt="스크린샷 2025-12-27 140844" src="https://github.com/user-attachments/assets/e4e25d44-e070-451b-a91c-63db3ef9b888" />
관리자가 아닌 사람이 구글 로그인 시도했을 시


## 💬 To. Reviewer
- manager의 ID를 integer_autofield로 지정해도 괜찮을까요? nanoid 등을 사용하는게 맞을까 싶습니다.
- 회원가입 기능 추가 커밋은 무시하셔도 됩니다. 처음에 이해를 잘못하고 개발했다가 지금은 불필요 코드를 모두 지운 상태입니다!
