### PR TITLE
지원서 작성 시 면접 선택지 목록 조회 API 구현

### DIFF
--- a/recruitments/serializers.py
+++ b/recruitments/serializers.py
@@ -1,1 +1,22 @@
+from __future__ import annotations
 from rest_framework import serializers
+
+# 날짜별 면접 슬롯(오전/오후) 응답 Serializer
+class InterviewGroupDateSerializer(serializers.Serializer):
+    date = serializers.CharField()
+    am = serializers.ListField(
+        child=serializers.CharField()
+    )
+    pm = serializers.ListField(
+        child=serializers.CharField()
+    )
+
+# 면접 선택지(날짜별/오전·오후) 응답 Serializer
+class InterviewGroupResponseSerializer(serializers.Serializer):
+    year = serializers.IntegerField()
+    part = serializers.CharField()
+    interview_method = serializers.CharField()
+    dates = InterviewGroupDateSerializer(
+        many=True
+    )
+

--- a/recruitments/services.py
+++ b/recruitments/services.py
@@ -1,1 +1,141 @@
+from __future__ import annotations
+
+from collections import defaultdict
+from datetime import timedelta
+
 from django.http import HttpRequest
+from django.db.models import Max
+from django.utils import timezone
+
+from recruitments.models import RecruitmentSchedule, InterviewSchedule
+from recruitments.serializers import InterviewGroupResponseSerializer
+from utils.choices import PartChoices, InterviewMethodChoices
+
+class InterviewScheduleService:
+
+    SLOT_MINUTES = 30
+
+    def __init__(self, request: HttpRequest):
+        self.request = request
+        self.serializer = None
+
+    def get_interview_group_options(self) -> dict:
+        part = self.request.query_params.get("part")
+        interview_method = self.request.query_params.get("interview_method")
+
+        self._validate_query_params(
+            part=part,
+            interview_method=interview_method
+        )
+
+        year = self._get_latest_year()
+
+        schedules = (
+            InterviewSchedule.objects.filter(
+                recruitment_schedule_id=year,
+                part=part,
+                interview_method=interview_method,
+            )
+            .only("start", "end")
+            .order_by("start")
+        )
+
+        if not schedules.exists():
+            raise InterviewSchedule.DoesNotExist
+
+        dates = self._build_dates_group(
+            schedules=schedules
+        )
+
+        payload = {
+            "year": year,
+            "part": part,
+            "interview_method": interview_method,
+            "dates": dates
+        }
+
+        self.serializer = InterviewGroupResponseSerializer(
+            data=payload
+        )
+        self.serializer.is_valid(
+            raise_exception=True
+        )
+        return self.serializer.data
+
+    def _validate_query_params(self, *, part: str | None, interview_method: str | None) -> None:
+        if not part or not interview_method:
+            raise ValueError("part and interview_method are required.")
+
+        valid_parts = {
+            choice.value
+            for choice in PartChoices
+        }
+        valid_methods = {
+            choice.value
+            for choice in InterviewMethodChoices
+        }
+
+        if part not in valid_parts or interview_method not in valid_methods:
+            raise ValueError("Invalid part or interview_method.")
+
+    def _get_latest_year(self) -> int:
+        year = RecruitmentSchedule.objects.aggregate(
+            mx=Max("year")
+        )["mx"]
+
+        if year is None:
+            raise RecruitmentSchedule.DoesNotExist
+
+        return year
+
+    def _to_kst_iso(self, dt) -> str:
+        return timezone.localtime(dt).isoformat(
+            timespec="seconds"
+        )
+
+    def _generate_slots(self, start_dt, end_dt):
+        step = timedelta(
+            minutes=self.SLOT_MINUTES
+        )
+        cur = start_dt
+
+        # start 포함, end 미포함
+        while cur < end_dt:
+            yield cur
+            cur += step
+
+    def _build_dates_group(self, *, schedules) -> list[dict]:
+        dates_map = defaultdict(
+            lambda: {"am": [], "pm": []}
+        )
+
+        for schedule in schedules:
+            start_dt = schedule.start
+            end_dt = schedule.end
+
+            if start_dt is None or end_dt is None or start_dt >= end_dt:
+                continue
+
+            for slot_dt in self._generate_slots(
+                start_dt=start_dt,
+                end_dt=end_dt
+            ):
+                local_dt = timezone.localtime(
+                    slot_dt
+                )
+                date_key = local_dt.date().isoformat()
+
+                if local_dt.hour < 12:
+                    dates_map[date_key]["am"].append(
+                        self._to_kst_iso(slot_dt)
+                    )
+                else:
+                    dates_map[date_key]["pm"].append(
+                        self._to_kst_iso(slot_dt)
+                    )
+
+        return [
+            {"date": d, "am": v["am"], "pm": v["pm"]}
+            for d, v in sorted(dates_map.items())
+        ]
+

--- a/recruitments/urls.py
+++ b/recruitments/urls.py
@@ -4,4 +4,9 @@ from .views import *
 app_name = 'recruitments'
 
 urlpatterns = [
+  path(
+        "application/interview-group/",
+        InterviewGroupView.as_view(),
+        name="interview-group"
+    ),
 ]

--- a/recruitments/views.py
+++ b/recruitments/views.py
@@ -1,3 +1,43 @@
-from django.shortcuts import render
+from rest_framework.views import APIView
+from rest_framework.response import Response
+from rest_framework import status
 
-# Create your views here.
+from recruitments.models import RecruitmentSchedule, InterviewSchedule
+from recruitments.services import InterviewScheduleService
+
+
+class InterviewGroupView(APIView):
+    """
+    GET /recuitments/application/interview-group/?part=BACKEND&interview_method=ONLINE
+    """
+
+    authentication_classes = []
+    permission_classes = []
+
+    def get(self, request):
+        service = InterviewScheduleService(
+            request=request
+        )
+
+        try:
+            data = service.get_interview_group_options()
+        except ValueError as e:
+            return Response(
+                {"message": str(e)},
+                status=status.HTTP_400_BAD_REQUEST
+            )
+        except RecruitmentSchedule.DoesNotExist:
+            return Response(
+                {"message": "Recruitment schedule not found."},
+                status=status.HTTP_404_NOT_FOUND
+            )
+        except InterviewSchedule.DoesNotExist:
+            return Response(
+                {"message": "Interview schedules not found for given conditions."},
+                status=status.HTTP_404_NOT_FOUND
+            )
+
+        return Response(
+            data,
+            status=status.HTTP_200_OK
+        )


### PR DESCRIPTION
## 🔎 What is this PR?
- 관련 API 명세서 링크
https://www.notion.so/2dacc780cd7d80a58593f359bbdaa2c6?source=copy_link

> 지원서 작성 단계에서 지원자가 선택할 면접 가능 시간(30분 단위) 목록을 조회하는 API를 구현했습니다.
> 모집 연도 기준으로 최신 RecruitmentSchedule을 조회합니다.
> 해당 연도의 InterviewSchedule을 기반으로 면접 가능 시간을 생성합니다.
> 
> 면접 시간은 30분 단위로 분할되며,
> 날짜별 + 오전(am) / 오후(pm) 로 그룹핑하여 응답합니다.

## ✨ Changes
### InterviewScheduleService 추가
- View와 비즈니스 로직을 분리하여 서비스 레이어에서 로직을 처리하도록 구현했습니다.
- 최신 모집 연도(RecruitmentSchedule.year)를 기준으로 면접 일정을 조회합니다.

### 30분 단위 면접 시간 생성 로직 구현
- start 포함, end 미포함 규칙으로 시간을 생성했습니다.

### 날짜별 + 오전/오후 그룹핑 응답 구조 구현
- 같은 날짜의 면접 시간을 하나로 묶고, 12시 이전은 am, 이후는 pm으로 구분하여 반환합니다.

### Query Parameter 검증 및 예외 처리
- part, interview_method 필수값 검증
- 모집 일정 또는 면접 일정이 없는 경우 명확한 에러 응답 반환

### API Endpoint 추가
- GET /recruitments/application/interview-group/
- Query Parameter: part (BACKEND | FRONTEND | PM_DESIGN), interview_method (ONLINE | OFFLINE)


## 📷 Result
- 스크린샷, 시연 영상 등
#41  구현 전이었어서 postgres db에 쿼리문을 넣어 조회를 시험해보았습니다. 
200OK
<img width="2940" height="1912" alt="image" src="https://github.com/user-attachments/assets/a2b7d333-d376-476f-b09a-2f30470624f4" />
<img width="2940" height="1912" alt="image" src="https://github.com/user-attachments/assets/11cde54a-0edb-47b6-ab7f-74f6d6581b78" />

404 Not Found (조건에 맞는 면접 일정이 존재하지 않는 경우)
<img width="2940" height="1912" alt="image" src="https://github.com/user-attachments/assets/8261a55d-4299-4cfa-8ad8-33337d453ee6" />


## 💬 To. Reviewer
- 집중적으로 리뷰를 원하는 부분이 있다면 작성해 주세요.
